### PR TITLE
Bugfix: Copy debug libs and set proper RPATH

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -226,7 +226,7 @@ int main(int argc, char **argv)
     }
 
     if (!qmlDirs.isEmpty()) {
-        bool ok = deployQmlImports(appBundlePath, deploymentInfo, qmlDirs, qmlImportPaths);
+        bool ok = deployQmlImports(appBundlePath, deploymentInfo, qmlDirs, qmlImportPaths, useDebugLibs);
         if (!ok && qmldirArgumentUsed)
             return 1; // exit if the user explicitly asked for qml import deployment
 

--- a/src/shared.cpp
+++ b/src/shared.cpp
@@ -878,7 +878,8 @@ void deployRPaths(const QString &bundlePath, const QSet<QString> &rpaths, const 
             rpathToFrameworksFound = true;
             continue;
         }
-        if (rpaths.contains(resolveDyldPrefix(rpath, binaryPath, binaryPath))) {
+        const QString dyldPrefix = resolveDyldPrefix(rpath, binaryPath, binaryPath);
+        if (rpaths.contains(dyldPrefix) || !QDir(dyldPrefix).exists()) {
             args << "-delete_rpath" << rpath;
         }
     }

--- a/src/shared.cpp
+++ b/src/shared.cpp
@@ -883,15 +883,15 @@ void deployRPaths(const QString &bundlePath, const QSet<QString> &rpaths, const 
             args << "-delete_rpath" << rpath;
         }
     }
-    if (!args.length()) {
-        return;
-    }
     if (!rpathToFrameworksFound) {
         if (!useLoaderPath) {
             args << "-add_rpath" << "@executable_path/../Frameworks";
         } else {
             args << "-add_rpath" << loaderPathToFrameworks;
         }
+    }
+    if (!args.length()) {
+        return;
     }
     LogDebug() << "Using install_name_tool:";
     LogDebug() << " change rpaths in" << binaryPath;

--- a/src/shared.h
+++ b/src/shared.h
@@ -121,7 +121,7 @@ DeploymentInfo deployQtFrameworks(const QString &appBundlePath, const QStringLis
 DeploymentInfo deployQtFrameworks(QList<FrameworkInfo> frameworks,const QString &bundlePath, const QStringList &binaryPaths, bool useDebugLibs, bool useLoaderPath);
 void createQtConf(const QString &appBundlePath);
 void deployPlugins(const QString &appBundlePath, DeploymentInfo deploymentInfo, bool useDebugLibs);
-bool deployQmlImports(const QString &appBundlePath, DeploymentInfo deploymentInfo, QStringList &qmlDirs, QStringList &qmlImportPaths);
+bool deployQmlImports(const QString &appBundlePath, DeploymentInfo deploymentInfo, QStringList &qmlDirs, QStringList &qmlImportPaths, bool useDebugLibs);
 void changeIdentification(const QString &id, const QString &binaryPath);
 void changeInstallName(const QString &oldName, const QString &newName, const QString &binaryPath);
 void runStrip(const QString &binaryPath);


### PR DESCRIPTION
Debug QML plugins still have loading issues, but at least all RPATHs are set correctly now, satisfying dyld.