### PR TITLE
Feature: add .appex bundle signing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.23)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.23)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(macdeployqt)

--- a/src/shared.h
+++ b/src/shared.h
@@ -129,6 +129,7 @@ void stripAppBinary(const QString &bundlePath);
 QString findAppBinary(const QString &appBundlePath);
 QStringList findAppFrameworkNames(const QString &appBundlePath);
 QStringList findAppFrameworkPaths(const QString &appBundlePath);
+QStringList findExtensionBundlePaths(const QString &appBundlePath);
 void codesignFile(const QString &identity, const QString &filePath);
 QSet<QString> codesignBundle(const QString &identity,
                              const QString &appBundlePath,


### PR DESCRIPTION
This adds .appex inner bundle signing, which are located inside a main bundle in ``<name>.app/Contents/PlugIns/<extension>.app``.
Currently, macdeployqt only scans for additional binaries and frameworks inside the PlugIns directory. Thus, to change the behavior, the following changes were required:
Inside the codesignBundle function:

1. Check if a file found under Contents/Plugins is a directory, that ends in .appex.
2. If so, remove all files in that path from the binaries list
3. Call codesignBundle recursively on the root path of that .appex bundle.